### PR TITLE
Cleanup namespaces/restore drive after all tests are done

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -91,11 +91,11 @@ def write_report(tests, drive, output_path):
 
 def restore_drive(config):
     drive = config['drive']['name']
-    psid = config['drive']['psid']
-    logger.info(f"Cleaning up drive {drive} through a format.")
-
-    # Start with a PSID reset, just in case it's in a weird state
-    sedutil.reset_via_psid(drive, psid)
+    psid = config['drive'].get('psid')
+    logger.info(f"Cleaning up drive {drive}")
+    if psid is not None:
+        # Start with a PSID reset
+        sedutil.reset_via_psid(drive, psid)
     # Format it.
     tree = n_utils.generate_resource_tree()
     n_utils.factory_reset(tree[drive]['sn'].strip())

--- a/src/main.py
+++ b/src/main.py
@@ -88,6 +88,11 @@ def write_report(tests, drive, output_path):
 
     r.close()
 
+def restore_drive(config):
+    drive = config['drive']['name']
+    tree = n_utils.generate_resource_tree()
+    n_utils.factory_reset(tree[drive]['sn'].strip())
+    return
 
 def main():
     parser = init_argparse()
@@ -120,6 +125,9 @@ def main():
             time.sleep(1)
         else:
             logger.info(f"Ignoring test: {test.name()}")
+
+    # cleanup any namespaces on the drive
+    restore_drive(config)
 
     logger.info("All tests complete.  Compiling report.")
     write_report(tests, config['drive']['name'], args.report)


### PR DESCRIPTION
This adds the change to clean up all namespaces using the `factory_reset()` utility method.
