### PR TITLE
Enable users to provide IO engine for perf tests, if not default to libaio

### DIFF
--- a/config-sample-ent-drive.yaml
+++ b/config-sample-ent-drive.yaml
@@ -22,7 +22,7 @@ test_config:
     max_ns: 32 # Max number of namespaces for the drive
     # If specified, this option will override the IO engine used for tests from libaio to specified engine
     # Can be an IO engine supported by OS, for ex: psync/sync/io_uring/windowsaio etc.
-    # io_engine: io_uring
+    io_engine: libaio
   perf_seq_write:
     bandwidth: 3000000 # 3 GB/s
   perf_seq_read:

--- a/config-sample-ent-drive.yaml
+++ b/config-sample-ent-drive.yaml
@@ -20,6 +20,7 @@ test_config:
     fio_runtime: 1200
     fio_ramptime: 60
     max_ns: 32 # Max number of namespaces for the drive
+    #ioengine: Specify the io engine for FIO to override the default libaio
   perf_seq_write:
     bandwidth: 3000000 # 3 GB/s
   perf_seq_read:

--- a/config-sample-ent-drive.yaml
+++ b/config-sample-ent-drive.yaml
@@ -20,7 +20,9 @@ test_config:
     fio_runtime: 1200
     fio_ramptime: 60
     max_ns: 32 # Max number of namespaces for the drive
-    #ioengine: Specify the io engine for FIO to override the default libaio
+    # If specified, this option will override the IO engine used for tests from libaio to specified engine
+    # Can be an IO engine supported by OS, for ex: psync/sync/io_uring/windowsaio etc.
+    # io_engine: io_uring
   perf_seq_write:
     bandwidth: 3000000 # 3 GB/s
   perf_seq_read:

--- a/src/tests/opal.py
+++ b/src/tests/opal.py
@@ -89,7 +89,7 @@ class OpalLockTest(run.Run):
 
         # FIO should fail
         rc, stdout, stderr = n_utils.run_cmd(
-            f'fio --name=seqread --iodepth=64 --rw=read --bs=256k --runtime=5 '
+            f'fio --name=seqread --iodepth=64 --rw=read --bs=128k --runtime=5 '
             f'--ramp=2 --group_reporting --numjobs=32 --sync=1 --direct=1 --size=100% '
             f'--filename=/dev/{self.drive}n1 --output-format=json', shell=True,
             fail_on_err=False)
@@ -114,7 +114,7 @@ class OpalLockTest(run.Run):
 
         # FIO should now pass
         rc, stdout, stderr = n_utils.run_cmd(
-            f'fio --name=seqread --iodepth=64 --rw=read --bs=256k --runtime=5 '
+            f'fio --name=seqread --iodepth=64 --rw=read --bs=128k --runtime=5 '
             f'--ramp=2 --group_reporting --numjobs=32 --sync=1 --direct=1 --size=100% '
             f'--filename=/dev/{self.drive}n1 --output-format=json', shell=True)
 

--- a/src/tests/perf.py
+++ b/src/tests/perf.py
@@ -29,7 +29,9 @@ class RandRead(run.Run):
         self.ramp = config['test_config']['general']['fio_ramptime']
         self.duration = config['test_config']['perf_rand_read'].get('runtime', \
             config['test_config']['general']['fio_runtime'])
+        self.ioengine = config['test_config']['general'].get('ioengine', 'libaio')
         self.min_iops = config['test_config']['perf_rand_read']['iops']
+
 
     def name(self):
         return "perf_rand_read"
@@ -50,7 +52,7 @@ class RandRead(run.Run):
 
         cmd = (f'fio --name=4krandread --iodepth=4 --rw=randread --bs=4k --runtime={self.duration} '
                f'--ramp={self.ramp} --group_reporting --numjobs=32 --sync=1 --direct=1 --size=100% '
-               f'--filename=/dev/{self.drive}n1 --output-format=json')
+               f'--ioengine={self.ioengine} --filename=/dev/{self.drive}n1 --output-format=json')
         self.logger.info(f"Command: {cmd}")
         rc, std_out, std_err = n_utils.run_cmd(cmd, shell=True)
 
@@ -82,6 +84,7 @@ class RandWrite(run.Run):
 
         self.drive = config['drive']['name']
         self.ramp = config['test_config']['general']['fio_ramptime']
+        self.ioengine = config['test_config']['general'].get('ioengine', 'libaio')
         self.duration = config['test_config']['perf_rand_write'].get('runtime', \
             config['test_config']['general']['fio_runtime'])
         self.min_iops = config['test_config']['perf_rand_write']['iops']
@@ -105,7 +108,7 @@ class RandWrite(run.Run):
 
         cmd = (f'fio --name=4krandwrite --iodepth=1 --rw=randwrite --bs=4k --runtime={self.duration} '
                f'--ramp={self.ramp} --group_reporting --numjobs=32 --sync=1 --direct=1 --size=100% '
-               f'--filename=/dev/{self.drive}n1 --output-format=json')
+               f'--ioengine={self.ioengine} --filename=/dev/{self.drive}n1 --output-format=json')
         self.logger.info(f"Command: {cmd}")
         rc, std_out, std_err = n_utils.run_cmd(cmd, shell=True)
 
@@ -137,6 +140,7 @@ class SeqMixed(run.Run):
 
         self.drive = config['drive']['name']
         self.ramp = config['test_config']['general']['fio_ramptime']
+        self.ioengine = config['test_config']['general'].get('ioengine', 'libaio')
         self.duration = config['test_config']['perf_seq_mixed'].get('runtime', \
             config['test_config']['general']['fio_runtime'])
         self.min_read_bw = config['test_config']['perf_seq_mixed']['bw_read']
@@ -161,9 +165,9 @@ class SeqMixed(run.Run):
         # Create a single namespace
         n_utils.factory_reset(tree[self.drive]['sn'].strip())
 
-        cmd = (f'fio --name=seqmixed --iodepth=64 --rw=rw --bs=256k --runtime={self.duration} '
+        cmd = (f'fio --name=seqmixed --iodepth=64 --rw=rw --bs=128k --runtime={self.duration} '
                f'--ramp={self.ramp} --group_reporting --numjobs=32 --sync=1 --direct=1 --size=100% '
-               f'--filename=/dev/{self.drive}n1 --output-format=json')
+               f'--ioengine={self.ioengine} --filename=/dev/{self.drive}n1 --output-format=json')
         self.logger.info(f"Command: {cmd}")
         rc, std_out, std_err = n_utils.run_cmd(cmd, shell=True)
 
@@ -209,6 +213,7 @@ class SeqRead(run.Run):
 
         self.drive = config['drive']['name']
         self.ramp = config['test_config']['general']['fio_ramptime']
+        self.ioengine = config['test_config']['general'].get('ioengine', 'libaio')
         self.duration = config['test_config']['perf_seq_read'].get('runtime', \
             config['test_config']['general']['fio_runtime'])
         self.min_bw = config['test_config']['perf_seq_read']['bandwidth']
@@ -230,9 +235,9 @@ class SeqRead(run.Run):
         # Create a single namespace
         n_utils.factory_reset(tree[self.drive]['sn'].strip())
 
-        cmd = (f'fio --name=seqread --iodepth=64 --rw=read --bs=256k --runtime={self.duration} '
+        cmd = (f'fio --name=seqread --iodepth=64 --rw=read --bs=128k --runtime={self.duration} '
                f'--ramp={self.ramp} --group_reporting --numjobs=32 --sync=1 --direct=1 --size=100% '
-               f'--filename=/dev/{self.drive}n1 --output-format=json')
+               f'--ioengine={self.ioengine} --filename=/dev/{self.drive}n1 --output-format=json')
         self.logger.info(f"Command: {cmd}")
         rc, std_out, std_err = n_utils.run_cmd(cmd, shell=True)
 
@@ -264,6 +269,7 @@ class SeqWrite(run.Run):
 
         self.drive = config['drive']['name']
         self.ramp = config['test_config']['general']['fio_ramptime']
+        self.ioengine = config['test_config']['general'].get('ioengine', 'libaio')
         self.duration = config['test_config']['perf_seq_write'].get('runtime', \
             config['test_config']['general']['fio_runtime'])
         self.min_bw = config['test_config']['perf_seq_write']['bandwidth']
@@ -285,9 +291,9 @@ class SeqWrite(run.Run):
         # Create a single namespace
         n_utils.factory_reset(tree[self.drive]['sn'].strip())
 
-        cmd = (f'fio --name=seqwrite --iodepth=64 --rw=write --bs=256k --runtime={self.duration} '
+        cmd = (f'fio --name=seqwrite --iodepth=64 --rw=write --bs=128k --runtime={self.duration} '
                f'--ramp={self.ramp} --group_reporting --numjobs=32 --sync=1 --direct=1 --size=100% '
-               f'--filename=/dev/{self.drive}n1 --output-format=json')
+               f'--ioengine={self.ioengine} --filename=/dev/{self.drive}n1 --output-format=json')
         self.logger.info(f"Command: {cmd}")
         rc, std_out, std_err = n_utils.run_cmd(cmd, shell=True)
 


### PR DESCRIPTION
The PR here provide users to configure how tests issue I/O through IO engine. It also includes a minor change to use 128K instead of 256K for tests.