### PR TITLE
Add a test for block SID auth function

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,3 +144,17 @@ chown root:root sedutil/Release_x86_64/sedutil-cli
 mv sedutil/Release_x86_64/sedutil-cli /usr/local/bin
 rm -rf ./sedutil*
 ```
+
+#### Test for Block SID Authentication
+
+Block SID: a mechanism by which a host application can alert the storage device
+to block attempts to authenticate the SID authority until a subsequent device power
+cycle occurs. This mechanism can be used by BIOS/platform firmware to prevent a
+malicious entity from taking ownership of a SID credential that is still set to
+its default value of MSID.
+
+- Fork of sedutil that supports Block SID: GitHub - [ChubbyAnt/sedutil](https://github.com/ChubbyAnt/sedutil)
+- Query output with `SID Blocked State = Y` would indicate that the initialsetup
+command is being blocked
+- Blocked State can be cleared with PSID revert to allow for the host to take ownership
+ of the drive

--- a/README.md
+++ b/README.md
@@ -153,7 +153,8 @@ cycle occurs. This mechanism can be used by BIOS/platform firmware to prevent a
 malicious entity from taking ownership of a SID credential that is still set to
 its default value of MSID.
 
-- Fork of sedutil that supports Block SID: GitHub - [ChubbyAnt/sedutil](https://github.com/ChubbyAnt/sedutil)
+- Current set of tests are written to use the fork of sedutil that supports Block
+SID until it is patched into the official build: GitHub - [ChubbyAnt/sedutil](https://github.com/ChubbyAnt/sedutil)
 - Query output with `SID Blocked State = Y` would indicate that the initialsetup
 command is being blocked
 - Blocked State can be cleared with PSID revert to allow for the host to take ownership

--- a/config-sample-ent-drive.yaml
+++ b/config-sample-ent-drive.yaml
@@ -4,6 +4,7 @@ drive:
 execute: # All tests run.
   - fw_update_simple
   - opal_capable
+  #- opal_block_sid # Test Block SID Authentication function
   - opal_test_locked_write
   - ns_layout
   - secure_erase_drive

--- a/config-sample-ent-drive.yaml
+++ b/config-sample-ent-drive.yaml
@@ -4,7 +4,7 @@ drive:
 execute: # All tests run.
   - fw_update_simple
   - opal_capable
-  #- opal_block_sid # Test Block SID Authentication function
+  #- opal_block_sid # Check README to learn about this test
   - opal_test_locked_write
   - ns_layout
   - secure_erase_drive

--- a/src/main.py
+++ b/src/main.py
@@ -59,6 +59,7 @@ def write_report(tests, drive, output_path):
     r.write(f"Model: {n_utils.get_controller_model(drive)}\n")
     r.write(f"Serial Num: {n_utils.get_controller_serial_number(drive)}\n")
     r.write(f"Firmware Level: {n_utils.get_controller_firmware(drive)}\n\n")
+    f.write(f"Drive Size: {n_utils.get_max_disk_size(drive)}\n\n")
 
     r.write(f"Tests Executed: {len(tests)}\n")
     r.write(f"Tests Passed: {len([t for t in tests if t.result()])}\n")
@@ -108,6 +109,7 @@ def main():
         config = yaml.safe_load(config_file)
 
     tests = [opal.OpalCapable(config),
+             opal.OpalBlockSIDTest(config),
              opal.OpalLockTest(config),
              namespaces.NSLayout(config),
              namespaces.ParallelIO(config),

--- a/src/nvme/sedutil.py
+++ b/src/nvme/sedutil.py
@@ -109,3 +109,18 @@ def query_drive(drive):
         sys.exit(1)
 
     return stdout
+
+
+def check_chubbyant_fork(drive):
+    output = query_drive(drive)
+    return 'Block SID Authentication' in output
+
+
+def is_default_msid(drive):
+    output = query_drive(drive)
+    return 'SID Value State = N' in output
+
+
+def is_sid_blocked(drive):
+    output = query_drive(drive)
+    return 'SID Blocked State = Y' and 'SID Value State = N' in output


### PR DESCRIPTION
Block SID can prevent the use of the initialsetup command as that relies on the drive being set to its
default value of MSID.
  – The Block SID would be set by the host during initial power on, therefore, the OS and user may not be
aware of this function
  – The test here makes use of a specific fork of [sedutil](https://github.com/ChubbyAnt/sedutil) to look up the BlockSID state and is intended to check whether a drive is set to the default value of MSID.
  